### PR TITLE
use finger list instead of orderdict

### DIFF
--- a/mano_grasp/kinematics.py
+++ b/mano_grasp/kinematics.py
@@ -24,7 +24,7 @@ class Kinematics:
         with open(os.path.join(path, 'kinematics.json'), 'r') as f:
             data = json.load(f)
         fingers = ['index', 'mid', 'pinky', 'ring', 'thumb']
-        self._chains = [Chain(n, data) for n in CHAIN_NAME.values()]
+        self._chains = [Chain(n, data) for n in fingers]#CHAIN_NAME.values()]
         self._origin = data['origin']
 
     def getManoPose(self, xyz, quat, dofs):


### PR DESCRIPTION
the OrderedDict.values() yields wrong ordering of kinematic chains
different python versions produce different outputs

and neither of the two produce the desired order 
`fingers = ['index', 'mid', 'pinky', 'ring', 'thumb']`

```
Python 2.7.12 (default, Oct  8 2019, 14:14:10) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import collections
>>> CHAIN_NAME = collections.OrderedDict(chain0='index',
...                                      chain1='mid',
...                                      chain2='ring',
...                                      chain3='pinky',
...                                      chain4='thumb')
>>> CHAIN_NAME.values()
['thumb', 'pinky', 'ring', 'mid', 'index']
>>> 
```
```
Python 3.5.2 (default, Oct  8 2019, 13:06:37) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import collections
>>> CHAIN_NAME = collections.OrderedDict(chain0='index',
...                                      chain1='mid',
...                                      chain2='ring',
...                                      chain3='pinky',
...                                      chain4='thumb')
>>> CHAIN_NAME.values()
odict_values(['ring', 'index', 'thumb', 'pinky', 'mid'])
>>> 
```

```
Python 3.6.10 (default, Jan 17 2020, 13:51:20) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import collections
>>> 
>>> CHAIN_NAME = collections.OrderedDict(chain0='index',
...                                      chain1='mid',
...                                      chain2='ring',
...                                      chain3='pinky',
...                                      chain4='thumb')
>>> CHAIN_NAME.values()
odict_values(['index', 'mid', 'ring', 'pinky', 'thumb'])
>>> 

```
